### PR TITLE
Update README.md with new link to soap api handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Beispiele für die Nutzung der Soap-Schnittstelle des Veransaltungskalenders
 
 Die Dateien sind Beispiele für die Nutzung der Soap-Schnittstelle von evangelische-termine.de in PHP. 
-Die Dokumentation finden Sie im Online-Handbuch: http://handbuch.evangelische-termine.de/soap-schnittstelle
+Die Dokumentation finden Sie im Online-Handbuch: https://handbuch.evangelische-termine.de/import/soap-api-dokumentation
 
 Bitte benennen Sie die Datei config_dist.php in config.php um und verändern die Konfigurtionswerte.


### PR DESCRIPTION
The old link is not available anymore I just added the new link a customer sent to me.